### PR TITLE
Fix tariffs

### DIFF
--- a/Api/Manifest/handler.js
+++ b/Api/Manifest/handler.js
@@ -154,7 +154,7 @@ module.exports.exportManifest = async event => {
 
     if (includeTariff) {
       const tariffHeaders = [
-        { name: 'Numero de partida', column: 'tariff_code', width: 15 },
+        { name: 'Numero de partida', column: 'tariff_nro_partida', width: 15 },
         { name: 'Descripcion', column: 'tariff_description', width: 30 },
         { name: 'Valor', column: 'tariff_tasa', width: 6, numFmt: '"%"#,##0' },
       ]

--- a/Api/Manifest/handler.js
+++ b/Api/Manifest/handler.js
@@ -93,8 +93,9 @@ module.exports.readPackagesByManifest = async event => {
   const connection = await mysql.createConnection(dbConfig)
   try {
     const manifest_id = event.pathParameters && event.pathParameters.id ? JSON.parse(event.pathParameters.id) : undefined
+    const noNullMaster = event.queryStringParameters && event.queryStringParameters.no_null_master
 
-    let [result] = await connection.execute(storage.getPackagesByManifestId(manifest_id))
+    let [result] = await connection.execute(storage.getPackagesByManifestId(manifest_id, noNullMaster))
 
     return response(200, result, connection)
   } catch (error) {

--- a/Api/Manifest/manifestStorage.js
+++ b/Api/Manifest/manifestStorage.js
@@ -25,7 +25,8 @@ const getPackagesByManifestId = manifest_id =>
   `SELECT A.package_id, A.tracking, S.name as supplier_name, C.client_name, A.weight, A.description,
     A.client_id as warehouse, A.costo_producto, A.cif, A.tasa, A.status, A.importe, A.guia, A.cif, A.dai,
     A.master, A.poliza, A.manifest_id, A.total_iva, A.total_a_pagar, A.ing_date, A.pieces, A.tariff_code,
-    A.voucher_bill, A.voucher_payment, T.description AS tariff_description, T.code AS tariff_code, T.tasa AS tariff_tasa
+    A.voucher_bill, A.voucher_payment, T.description AS tariff_description, T.id AS tariff_code,
+    T.code AS tariff_nro_partida, T.tasa AS tariff_tasa
     FROM paquetes A
     LEFT JOIN clientes C on A.client_id = C.client_id 
     LEFT JOIN suppliers S on A.supplier_id = S.id

--- a/Api/Manifest/manifestStorage.js
+++ b/Api/Manifest/manifestStorage.js
@@ -21,7 +21,7 @@ const getMAXManifest = () => `SELECT MAX(manifest_id) as manifest_id from manife
 const updateManifest = (data, id) => `UPDATE manifest SET description='${data.description.toUpperCase()}', 
                                       status='${data.status}' WHERE manifest_id=${id};`
 
-const getPackagesByManifestId = manifest_id =>
+const getPackagesByManifestId = (manifest_id, noNullMaster) =>
   `SELECT A.package_id, A.tracking, S.name as supplier_name, C.client_name, A.weight, A.description,
     A.client_id as warehouse, A.costo_producto, A.cif, A.tasa, A.status, A.importe, A.guia, A.cif, A.dai,
     A.master, A.poliza, A.manifest_id, A.total_iva, A.total_a_pagar, A.ing_date, A.pieces, A.tariff_code,
@@ -31,7 +31,8 @@ const getPackagesByManifestId = manifest_id =>
     LEFT JOIN clientes C on A.client_id = C.client_id 
     LEFT JOIN suppliers S on A.supplier_id = S.id
     LEFT JOIN tariffs T on A.tariff_code = T.id
-    WHERE manifest_id = ${manifest_id}`
+    WHERE A.manifest_id = ${manifest_id}
+    ${noNullMaster ? 'AND A.master = "" AND A.poliza IS NULL' : ''}`
 
 module.exports = {
   createManifest,


### PR DESCRIPTION
## Pull Request Description
- [x] QA @userlab-luismoreno 
- [ ] CR @userlab-luisdeleon 

## What changed?
- Se modifico la respuesta del endpoint ```GET - manifest/detail/{manifest_id}```. Ahora incluye las keys tariff_code (id de la partida arancelaria en base de datos) y tariff_nro_partida (codigo de partida arancelaria)
- Al mismo endpoint se le agrego soporte para retornar solo paquetes que no contengan ni poliza ni master al recibir el queryParam `no_null_master`

## Test plan
N/A