### PR TITLE
Fix update manifest

### DIFF
--- a/Api/Manifest/handler.js
+++ b/Api/Manifest/handler.js
@@ -125,7 +125,7 @@ module.exports.exportManifest = async event => {
                   ...r,
                   [k]: row[k],
                   pesoKg: Number(row[k] * poundToKgFactor).toFixed(2),
-                  valorFlete: Math.ceil(row[k] * poundToKgFactor * 2),
+                  valorFlete: Number(row[k] * poundToKgFactor * 2).toFixed(2),
                 }
               }
 

--- a/Api/Manifest/manifestStorage.js
+++ b/Api/Manifest/manifestStorage.js
@@ -26,13 +26,13 @@ const getPackagesByManifestId = (manifest_id, noNullMaster) =>
     A.client_id as warehouse, A.costo_producto, A.cif, A.tasa, A.status, A.importe, A.guia, A.cif, A.dai,
     A.master, A.poliza, A.manifest_id, A.total_iva, A.total_a_pagar, A.ing_date, A.pieces, A.tariff_code,
     A.voucher_bill, A.voucher_payment, T.description AS tariff_description, T.id AS tariff_code,
-    T.code AS tariff_nro_partida, T.tasa AS tariff_tasa
+    T.code AS tariff_nro_partida, CAST((T.tasa * 100) AS SIGNED) AS tariff_tasa
     FROM paquetes A
     LEFT JOIN clientes C on A.client_id = C.client_id 
     LEFT JOIN suppliers S on A.supplier_id = S.id
     LEFT JOIN tariffs T on A.tariff_code = T.id
     WHERE A.manifest_id = ${manifest_id}
-    ${noNullMaster ? 'AND A.master = "" AND A.poliza IS NULL' : ''}`
+    ${noNullMaster ? 'AND A.master = "" AND A.poliza = ""' : ''}`
 
 module.exports = {
   createManifest,

--- a/Api/Packages/packageStorage.js
+++ b/Api/Packages/packageStorage.js
@@ -323,6 +323,12 @@ const manifestsBulkUpdate = manifestValues => `
     status = VALUES(status);
 `
 
+const getUncompleteManifests = manifestIds => `
+  SELECT manifest_id
+  FROM paquetes
+  WHERE manifest_id IN (${manifestIds.join(', ')}) AND master = "" AND poliza = ""
+`
+
 module.exports = {
   get: read,
   post: create,
@@ -351,4 +357,5 @@ module.exports = {
   manifestsBulkUpdate,
   getTariffs,
   updatePackageTariff,
+  getUncompleteManifests,
 }

--- a/Api/Packages/packageStorage.js
+++ b/Api/Packages/packageStorage.js
@@ -54,7 +54,9 @@ const getTariffs = fields => {
 const updatePackageTariff = (tariff_code, package_id) => `
   UPDATE paquetes SET
     tariff_code = ${tariff_code},
-    tasa = (SELECT tasa FROM tariffs WHERE id = ${tariff_code})
+    tasa = (SELECT tasa FROM tariffs WHERE id = ${tariff_code}),
+    dai = (cif * (SELECT tasa FROM tariffs WHERE id = ${tariff_code})),
+    total_iva = ((cif + (cif * (SELECT tasa FROM tariffs WHERE id = ${tariff_code}))) * 0.12)
   WHERE package_id = ${package_id}
 `
 


### PR DESCRIPTION
## Pull Request Description
- [x] QA @userlab-luismoreno 
- [ ] CR @userlab-luisdeleon 

## What changed?
- Se modifico la columna "Valor flete" del excel del manifiesto. Antes se redondeaba el valor y ahora se muestra con dos decimales.
- Ahora en el endpoint `PUT - packages/bulk-update` solo se cambia el status del manifiesto a 'CLOSED' cuando el mismo no contenga ningun paquete con poliza ni master iguales a un string vacio
- Se modificaron los valores de la columna "tasa" de la tabla "tariffs" de enteros a decimales (se dividieron entre 100) para coincidir con los valores usados en la tabla " paquetes"

## Test plan
N/A