### PR TITLE
Fix uncomplete manifest query

### DIFF
--- a/Api/Manifest/manifestStorage.js
+++ b/Api/Manifest/manifestStorage.js
@@ -32,7 +32,7 @@ const getPackagesByManifestId = (manifest_id, noNullMaster) =>
     LEFT JOIN suppliers S on A.supplier_id = S.id
     LEFT JOIN tariffs T on A.tariff_code = T.id
     WHERE A.manifest_id = ${manifest_id}
-    ${noNullMaster ? 'AND A.master = "" AND A.poliza = ""' : ''}`
+    ${noNullMaster ? 'AND (A.master = "" OR A.master IS NULL) AND (A.poliza = "" OR A.poliza IS NULL)' : ''}`
 
 module.exports = {
   createManifest,

--- a/Api/Packages/packageStorage.js
+++ b/Api/Packages/packageStorage.js
@@ -328,7 +328,10 @@ const manifestsBulkUpdate = manifestValues => `
 const getUncompleteManifests = manifestIds => `
   SELECT manifest_id
   FROM paquetes
-  WHERE manifest_id IN (${manifestIds.join(', ')}) AND master = "" AND poliza = ""
+  WHERE
+    manifest_id IN (${manifestIds.join(', ')})
+    AND (master = "" OR master IS NULL)
+    AND (poliza = "" OR poliza IS NULL)
 `
 
 module.exports = {


### PR DESCRIPTION
## Pull Request Description
- [x] QA @userlab-luismoreno 
- [ ] CR @userlab-luisdeleon 

## What changed?
- Se modifico el where clause para obetener los manifiestos incompletos de la base de datos. Ahora se verifica si el manifiesto contiene paquetes con los campos poliza y master con un string vacio o NULL
```
AND (A.master = "" OR A.master IS NULL) AND (A.poliza = "" OR A.poliza IS NULL)
```

## Test plan
N/A